### PR TITLE
Replace partial match of `std` to `std.err`

### DIFF
--- a/R/survfitKM.R
+++ b/R/survfitKM.R
@@ -224,9 +224,9 @@ survfitKM <- function(x, y, weights=rep(1.0,length(x)),
                       n.event= unlist(lapply(cfit, function(x) x$n[,5])),
                       n.censor=unlist(lapply(cfit, function(x) x$n[,6])),
                       surv =   unlist(lapply(cfit, function(x) x$estimate[,1])),
-                      std.err =unlist(lapply(cfit, function(x) x$std[,1])),
+                      std.err =unlist(lapply(cfit, function(x) x$std.err[,1])),
                       cumhaz  =unlist(lapply(cfit, function(x) x$estimate[,2])),
-                      std.chaz=unlist(lapply(cfit, function(x) x$std[,2])),
+                      std.chaz=unlist(lapply(cfit, function(x) x$std.err[,2])),
                       strata=strata)
           if (ny==3) rval$n.enter <- unlist(lapply(cfit, function(x) x$n[,8]))
     }

--- a/R/survfitKM.R
+++ b/R/survfitKM.R
@@ -211,9 +211,9 @@ survfitKM <- function(x, y, weights=rep(1.0,length(x)),
                      n.event= cfit$n[,5],
                      n.censor=cfit$n[,6],
                      surv = cfit$estimate[,1],
-                     std.err = cfit$std[,1],
+                     std.err = cfit$std.err[,1],
                      cumhaz  = cfit$estimate[,2],
-                     std.chaz = cfit$std[,2])
+                     std.chaz = cfit$std.err[,2])
      } else {
          strata <- sapply(cfit, function(x) if (is.null(x$n)) 0L else nrow(x$n))
          names(strata) <- xlev


### PR DESCRIPTION
While testing on {GGally}, I found this partial match:

```
Warning (test-ggsurv.R:90:3): back.white
partial match of 'std' to 'std.err'
Backtrace:
 1. survival::survfit(Surv(time, status) ~ disease, data = kidney) test-ggsurv.R:90:2
 2. survival::survfit.formula(Surv(time, status) ~ disease, data = kidney)
 3. survival::survfitKM(...)
 5. base::lapply(cfit, function(x) x$std[, 1])
 6. survival:::FUN(X[[i]], ...)

Warning (test-ggsurv.R:90:3): back.white
partial match of 'std' to 'std.err'
Backtrace:
 1. survival::survfit(Surv(time, status) ~ disease, data = kidney) test-ggsurv.R:90:2
 2. survival::survfit.formula(Surv(time, status) ~ disease, data = kidney)
 3. survival::survfitKM(...)
 5. base::lapply(cfit, function(x) x$std[, 2])
 6. survival:::FUN(X[[i]], ...)
```

With this PR, the warnings go away.